### PR TITLE
Update hnap-rev1.2-lan.yaml

### DIFF
--- a/hnap-rev1.2-lan.yaml
+++ b/hnap-rev1.2-lan.yaml
@@ -155,7 +155,9 @@ ethernet:
   type: RTL8201
   mdc_pin: GPIO16
   mdio_pin: GPIO17
-  clk_mode: GPIO0_IN
+  clk:
+    pin: GPIO0
+    mode: CLK_EXT_IN
   phy_addr: 0
   phy_registers:
     - address: 0x10


### PR DESCRIPTION
This warning has been popping up in the logs:
```
WARNING [ethernet] The 'clk_mode' option is deprecated and will be removed in ESPHome 2026.1. Please update your configuration to use 'clk' instead.
```
After this change, the warning went away.
Took the new config from [this page](https://esphome.io/components/ethernet/) for the WESP32 >= rev.7.

