### PR TITLE
Remove slash from pin name

### DIFF
--- a/packages/hnap-rev1.2-misc-io.yaml
+++ b/packages/hnap-rev1.2-misc-io.yaml
@@ -18,7 +18,7 @@ binary_sensor:
   # I/O Header Pin 1 - wESP32 IO2
   - platform: gpio
     id: Misc1
-    name: Misc I/O - Pin 01
+    name: Misc IO - Pin 01
     pin: 
       number: GPIO2
       mode:
@@ -33,7 +33,7 @@ binary_sensor:
   # I/O Header Pin 3 - wESP32 IO2
   - platform: gpio
     id: Misc2
-    name: Misc I/O - Pin 03
+    name: Misc IO - Pin 03
     pin: 
       number: GPIO12
       mode:
@@ -46,7 +46,7 @@ binary_sensor:
   # I/O Header Pin 4 - MCP23017_4 IO10
   - platform: gpio
     id: Misc6
-    name: Misc I/O - Pin 04
+    name: Misc IO - Pin 04
     pin: 
       mcp23xxx: mcp23017_4
       number: 10
@@ -60,7 +60,7 @@ binary_sensor:
   # I/O Header Pin 5 - wESP32 IO14
   - platform: gpio
     id: Misc3
-    name: Misc I/O - Pin 05
+    name: Misc IO - Pin 05
     pin: 
       number: GPIO14
       mode:
@@ -73,7 +73,7 @@ binary_sensor:
   # I/O Header Pin 6 - MCP23017_4 IO11
   - platform: gpio
     id: Misc7
-    name: Misc I/O - Pin 06
+    name: Misc IO - Pin 06
     pin: 
       mcp23xxx: mcp23017_4
       number: 11
@@ -87,7 +87,7 @@ binary_sensor:
   # I/O Header Pin 7 - wESP32 IO5
   - platform: gpio
     id: Misc4
-    name: Misc I/O - Pin 07
+    name: Misc IO - Pin 07
     pin: 
       number: GPIO5
       mode:
@@ -100,7 +100,7 @@ binary_sensor:
   # I/O Header Pin 8 - MCP23017_4 IO12
   - platform: gpio
     id: Misc8
-    name: Misc I/O - Pin 08
+    name: Misc IO - Pin 08
     pin: 
       mcp23xxx: mcp23017_4
       number: 12
@@ -114,7 +114,7 @@ binary_sensor:
   # I/O Header Pin 9 - wESP32 IO33
   - platform: gpio
     id: Misc5
-    name: Misc I/O - Pin 09
+    name: Misc IO - Pin 09
     pin: 
       number: GPIO33
       mode:
@@ -127,7 +127,7 @@ binary_sensor:
   # I/O Header Pin 10 - MCP23017_4 IO13
   - platform: gpio
     id: Misc9
-    name: Misc I/O - Pin 10
+    name: Misc IO - Pin 10
     pin: 
       mcp23xxx: mcp23017_4
       number: 13
@@ -143,7 +143,7 @@ binary_sensor:
   # I/O Header Pin 12 - MCP23017_4 IO14
   - platform: gpio
     id: Misc10
-    name: Misc I/O - Pin 12
+    name: Misc IO - Pin 12
     pin: 
       mcp23xxx: mcp23017_4
       number: 14
@@ -159,7 +159,7 @@ binary_sensor:
   # I/O Header Pin 14 - MCP23017_4 IO15
   - platform: gpio
     id: Misc11
-    name: Misc I/O - Pin 14
+    name: Misc IO - Pin 14
     pin: 
       mcp23xxx: mcp23017_4
       number: 15


### PR DESCRIPTION
ESPHome is throwing these warnings, which will become errors in July:
```
WARNING 'Misc I/O - Pin 01' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 01' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING GPIO2 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING 'Misc I/O - Pin 03' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 03' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING GPIO12 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING 'Misc I/O - Pin 04' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 04' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 05' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 05' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 06' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 06' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 07' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 07' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING GPIO5 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING 'Misc I/O - Pin 08' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 08' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 09' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 09' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 10' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 10' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 12' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 12' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Misc I/O - Pin 14' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Misc I⁄O - Pin 14' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
```
I just removed the slashes, `I/O` --> `IO`

After the change, no more warnings (about the slashes):
```
INFO ESPHome 2026.2.4
INFO Reading configuration /config/esphome/hornet-nest-3cad44.yaml...
WARNING GPIO15 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING GPIO2 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING GPIO12 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING GPIO5 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
WARNING GPIO0 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
INFO Generating C++ source...
INFO Setting CONFIG_LWIP_MAX_SOCKETS to 13 (registered: api=4, mdns=2, ota=1, web_server=6)
INFO Compiling app... Build path: /data/build/hornet-nest-3cad44
...
```